### PR TITLE
Use realpath in fish.sh

### DIFF
--- a/fish.sh
+++ b/fish.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
 export TERMINFO_DIRS=/lib/terminfo:/etc/terminfo:/usr/share/terminfo:$TERMINFO_DIRS
-CURRENT_DIR="$(cd "$(dirname "$(realpath "$0" )" )" && pwd)"
+
+if command -v realpath >/dev/null 2>&1 ; then
+  CURRENT_DIR="$(cd "$(dirname "$(realpath "$0" )" )" && pwd)"
+else
+  CURRENT_DIR="$(cd "$(dirname             "$0"    )" && pwd)"
+fi
+
 $CURRENT_DIR/fish "$@"

--- a/fish.sh
+++ b/fish.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 export TERMINFO_DIRS=/lib/terminfo:/etc/terminfo:/usr/share/terminfo:$TERMINFO_DIRS
-CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CURRENT_DIR="$(cd "$(dirname "$(realpath "$0" )" )" && pwd)"
 $CURRENT_DIR/fish "$@"


### PR DESCRIPTION
This allows symlinks to the shell script - the directory in which it resides was evaluating to the location of the link, not its target. Not exhaustively tested, feel free to change.